### PR TITLE
Correction erreur contraste Wave

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,12 +101,12 @@
               type="button"
               data-bs-target="#carouselExampleIndicators"
               data-bs-slide="prev"
+              aria-label="Précédent"
             >
               <span
                 class="carousel-control-prev-icon"
                 aria-hidden="true"
               ></span>
-              <span class="visually-hidden">Précédent</span>
             </button>
             <figure class="carousel-item active">
               <img
@@ -172,9 +172,9 @@
             type="button"
             data-bs-target="#carouselExampleIndicators"
             data-bs-slide="next"
+            aria-label="Suivant"
           >
             <span class="carousel-control-next-icon" aria-hidden="true"></span>
-            <span class="visually-hidden">Suivant</span>
           </button>
           <div class="carousel-indicators">
             <button


### PR DESCRIPTION
- Suppression des span avec la class visually-hidden qui engendre une erreur de contraste dans Wave ;
- Et ajout d'un aria-label sur les boutons pour indiquer suivant ou précédent.